### PR TITLE
Modularize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM modm/arm-none-eabi-gcc:latest
-LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>"
-LABEL Description="Image for building and debugging modm for ARM and AVR from git"
+LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann <raphael+docker@rleh.de"
+LABEL Description="Image for building and debugging modm for ARM, AVR and RISC-V"
 WORKDIR /work
 
 ADD requirements3.txt /work
@@ -37,9 +37,9 @@ RUN locale-gen en_US.UTF-8 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
     update-alternatives --set python /usr/bin/python3.8
 RUN pip3 install -r requirements3.txt && rm requirements3.txt
-RUN wget -qO- https://github.com/modm-ext/riscv-gcc/releases/download/v10.1.0/riscv-gcc.tar.bz2 | tar xj -C /opt
+RUN wget -qO- https://github.com/modm-ext/riscv-gcc/releases/download/v10.2.0/modm-riscv-gcc.tar.bz2 | tar xj -C /opt
 RUN wget -qO- https://github.com/modm-ext/docker-avr-gcc/releases/download/v10.2.0/avr-gcc.tar.bz2 | tar xj -C /opt
 RUN mkdir /opt/doxypress && \
     wget -qO- https://download.copperspice.com/doxypress/binary/doxypress-1.4.0-ubuntu20.04-x64.tar.bz2 | tar xj -C /opt/doxypress
 
-ENV PATH "/opt/doxypress:/opt/avr-gcc/avr-gcc/bin:/opt/avr-gcc/avr-binutils/bin:/opt/riscv-gcc/bin:$PATH"
+ENV PATH "/opt/doxypress:/opt/avr-gcc/avr-gcc/bin:/opt/avr-gcc/avr-binutils/bin:/opt/modm-riscv-gcc/bin:$PATH"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+TARGET_IMAGES = avr cortex-m risc-v
+IMAGES = base $(TARGET_IMAGES)
+PUSH_LIST = $(addprefix push-, $(IMAGES))
+
+.PHONY: all $(IMAGES) $(PUSH_LIST)
+
+all: $(IMAGES)
+
+$(TARGET_IMAGES): base
+
+# TODO: Put in a single rule...
+base: base.Dockerfile
+	docker build --tag modm/modm-build:$@ --file $< .
+avr: avr.Dockerfile
+	docker build --tag modm/modm-build:$@ --file $< .
+cortex-m: cortex-m.Dockerfile
+	docker build --tag modm/modm-build:$@ --file $< .
+risc-v: risc-v.Dockerfile
+	docker build --tag modm/modm-build:$@ --file $< .
+
+$(PUSH_LIST):
+	docker push modm/modm-build:$(@:push-%=%)
+
+push: $(PUSH_LIST)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # docker-modm-build
 
-Docker container for building modm for ARM Cortex-M and Atmel AVR8 targets.
+Docker containers for building modm for different architectures:
 
-    docker pull modm/modm-build
+* ARM Cortex-M (STM32, SAMD, ...): `docker pull modm/modm-build:cortex-m`
+* Atmel/Microchip AVR: `docker pull modm/modm-build:avr`
+* RISC-V: `docker pull modm/modm-build:risc-v`
+* Hosted (Linux): `docker pull modm/modm-build:base`
+
+## Build images
+
+```bash
+make all -j4
+
+# Push to dockerhub
+make push -j4
+```

--- a/avr.Dockerfile
+++ b/avr.Dockerfile
@@ -1,0 +1,7 @@
+FROM modm/modm-build:base
+LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann <raphael+docker@rleh.de"
+LABEL Description="Image for building and debugging modm for AVR"
+
+RUN wget -qO- https://github.com/modm-ext/docker-avr-gcc/releases/download/v10.2.0/avr-gcc.tar.bz2 | tar xj -C /opt
+
+ENV PATH "/opt/avr-gcc/avr-gcc/bin:/opt/avr-gcc/avr-binutils/bin:$PATH"

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,6 +1,7 @@
-FROM modm/arm-none-eabi-gcc:latest
+FROM ubuntu:20.04
 LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann <raphael+docker@rleh.de"
-LABEL Description="Image for building and debugging modm for ARM, AVR and RISC-V"
+LABEL description="Image for building and debugging modm"
+
 WORKDIR /work
 
 ADD requirements3.txt /work
@@ -11,10 +12,13 @@ ENV SCONSFLAGS="-j4"
 ENV TZ=Europe/Berlin
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install any needed packages specified in requirements.txt
 RUN apt-get update -qq && \
     apt-get upgrade -y -qq && \
     apt-get install -y -qq \
+      build-essential \
+      git \
+      bzip2 \
+      wget \
       python3 \
       python3-dev \
       python3-pip \
@@ -33,13 +37,9 @@ RUN apt-get update -qq && \
       graphviz \
       curl && \
     apt-get clean -qq
-RUN locale-gen en_US.UTF-8 && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
-    update-alternatives --set python /usr/bin/python3.8
+RUN locale-gen en_US.UTF-8
 RUN pip3 install -r requirements3.txt && rm requirements3.txt
-RUN wget -qO- https://github.com/modm-ext/riscv-gcc/releases/download/v10.2.0/modm-riscv-gcc.tar.bz2 | tar xj -C /opt
-RUN wget -qO- https://github.com/modm-ext/docker-avr-gcc/releases/download/v10.2.0/avr-gcc.tar.bz2 | tar xj -C /opt
 RUN mkdir /opt/doxypress && \
     wget -qO- https://download.copperspice.com/doxypress/binary/doxypress-1.4.0-ubuntu20.04-x64.tar.bz2 | tar xj -C /opt/doxypress
 
-ENV PATH "/opt/doxypress:/opt/avr-gcc/avr-gcc/bin:/opt/avr-gcc/avr-binutils/bin:/opt/modm-riscv-gcc/bin:$PATH"
+ENV PATH "/opt/doxypress:$PATH"

--- a/cortex-m.Dockerfile
+++ b/cortex-m.Dockerfile
@@ -1,0 +1,7 @@
+FROM modm/modm-build:base
+LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann <raphael+docker@rleh.de"
+LABEL Description="Image for building and debugging modm for ARM Cortex-M"
+
+RUN wget -qO- https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 | tar -xj -C /opt
+
+ENV PATH "/opt/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH"

--- a/risc-v.Dockerfile
+++ b/risc-v.Dockerfile
@@ -1,0 +1,7 @@
+FROM modm/modm-build:base
+LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann <raphael+docker@rleh.de"
+LABEL Description="Image for building and debugging modm for RISC-V"
+
+RUN wget -qO- https://github.com/modm-ext/riscv-gcc/releases/download/v10.2.0/modm-riscv-gcc.tar.bz2 | tar xj -C /opt
+
+ENV PATH "/opt/modm-riscv-gcc/bin:$PATH"


### PR DESCRIPTION
- [x] Split modm-build docker image into multiple small images
  * Hosted (Linux): `modm/modm-build:base` (the following images are based on this image)
  * ARM Cortex-M (STM32, SAMD, ...): `modm/modm-build:cortex-m`
  * Atmel/Microchip AVR: `modm/modm-build:avr`
  * RISC-V: `modm/modm-build:risc-v`
- [x] Update RISC-V GCC to 10.2.0, with multilib now (Closes #13)