### PR TITLE
Update ARM GCC to v10.3

### DIFF
--- a/cortex-m.Dockerfile
+++ b/cortex-m.Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann 
 LABEL Description="Image for building and debugging modm for ARM Cortex-M"
 LABEL org.opencontainers.image.source https://github.com/modm-ext/docker-modm-build
 
-RUN wget -qO- https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 | tar -xj -C /opt
+RUN wget -qO- https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2 | tar -xj -C /opt
 
-ENV PATH "/opt/gcc-arm-none-eabi-10-2020-q4-major/bin:$PATH"
+ENV PATH "/opt/gcc-arm-none-eabi-10.3-2021.07/bin:$PATH"


### PR DESCRIPTION
There was a small arm-none-eabi-gcc update.
https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads

cc @rleh 