### PR TITLE
Update RISC-V and AVR GCC to version 11

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,7 +37,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/modm-ext/modm-build-base:${{ env.VERSION }}
-            ghcr.io/modm-ext/modm-build-base:latest
+            ghcr.io/modm-ext/modm-build-base:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
 
 
       - name: Build and push modm-build-avr
@@ -49,7 +49,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/modm-ext/modm-build-avr:${{ env.VERSION }}
-            ghcr.io/modm-ext/modm-build-avr:latest
+            ghcr.io/modm-ext/modm-build-avr:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
 
       - name: Build and push modm-build-cortex-m
         uses: docker/build-push-action@v2
@@ -60,7 +60,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/modm-ext/modm-build-cortex-m:${{ env.VERSION }}
-            ghcr.io/modm-ext/modm-build-cortex-m:latest
+            ghcr.io/modm-ext/modm-build-cortex-m:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
 
       - name: Build and push modm-build-risc-v
         uses: docker/build-push-action@v2
@@ -71,4 +71,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/modm-ext/modm-build-risc-v:${{ env.VERSION }}
-            ghcr.io/modm-ext/modm-build-risc-v:latest
+            ghcr.io/modm-ext/modm-build-risc-v:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}

--- a/avr.Dockerfile
+++ b/avr.Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann 
 LABEL Description="Image for building and debugging modm for AVR"
 LABEL org.opencontainers.image.source https://github.com/modm-ext/docker-modm-build
 
-RUN wget -qO- https://github.com/modm-io/avr-gcc/releases/download/v10.2.0/avr-gcc.tar.bz2 | tar xj -C /opt
+RUN wget -qO- https://github.com/modm-io/avr-gcc/releases/download/v11.2.0/modm-avr-gcc.tar.bz2 | tar xj -C /opt
 
-ENV PATH "/opt/avr-gcc/avr-gcc/bin:/opt/avr-gcc/avr-binutils/bin:$PATH"
+ENV PATH "/opt/avr-gcc/bin:$PATH"

--- a/risc-v.Dockerfile
+++ b/risc-v.Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann 
 LABEL Description="Image for building and debugging modm for RISC-V"
 LABEL org.opencontainers.image.source https://github.com/modm-ext/docker-modm-build
 
-RUN wget -qO- https://github.com/modm-io/riscv-gcc/releases/download/v10.2.0/modm-riscv-gcc.tar.bz2 | tar xj -C /opt
+RUN wget -qO- https://github.com/modm-io/riscv-gcc/releases/download/v11.1.0/modm-riscv-gcc.tar.bz2 | tar xj -C /opt
 
 ENV PATH "/opt/modm-riscv-gcc/bin:$PATH"


### PR DESCRIPTION
- [x] RISC-V GCC 11.1.0
- [x] AVR-GCC 11.2.0
  - modm-io/avr-gcc#4