### PR TITLE
added openocd image on top of arm image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,6 +23,7 @@ jobs:
          for dockerfile in *.Dockerfile; do
           sed -i "s/modm-build-base:TAG/modm-build-base:${{ env.VERSION }}/g" $dockerfile
          done
+         sed -i "s/modm-build-cortex-m:TAG/modm-build-cortex-m:${{ env.VERSION }}/g" cortex-m-openocd.Dockerfile
          git diff
 
       - name: Set up Docker Buildx
@@ -68,6 +69,17 @@ jobs:
           tags: |
             ghcr.io/modm-ext/modm-build-cortex-m:${{ env.VERSION }}
             ghcr.io/modm-ext/modm-build-cortex-m:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
+
+      - name: Build and push modm-build-cortex-m-openocd
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./cortex-m-openocd.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/modm-ext/modm-build-cortex-m-openocd:${{ env.VERSION }}
+            ghcr.io/modm-ext/modm-build-cortex-m-openocd:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
 
       - name: Build and push modm-build-risc-v
         uses: docker/build-push-action@v2

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGET_IMAGES = avr cortex-m risc-v
+TARGET_IMAGES = avr cortex-m risc-v cortex-m-openocd
 IMAGES = base $(TARGET_IMAGES)
 PUSH_LIST = $(addprefix push-, $(IMAGES))
 
@@ -23,6 +23,10 @@ avr: avr.Dockerfile
 	docker tag ghcr.io/modm-ext/modm-build-$@:$(DATE) ghcr.io/modm-ext/modm-build-$@:testing
 cortex-m: cortex-m.Dockerfile
 	cat $< | sed "s/modm-build-base:TAG/modm-build-base:$(DATE)/g" | \
+	docker build --tag ghcr.io/modm-ext/modm-build-$@:$(DATE) -
+	docker tag ghcr.io/modm-ext/modm-build-$@:$(DATE) ghcr.io/modm-ext/modm-build-$@:testing
+cortex-m-openocd: cortex-m-openocd.Dockerfile cortex-m
+	cat $< | sed "s/modm-build-cortex-m:TAG/modm-build-cortex-m:$(DATE)/g" | \
 	docker build --tag ghcr.io/modm-ext/modm-build-$@:$(DATE) -
 	docker tag ghcr.io/modm-ext/modm-build-$@:$(DATE) ghcr.io/modm-ext/modm-build-$@:testing
 risc-v: risc-v.Dockerfile

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Docker containers for building modm for different architectures:
 * Atmel/Microchip AVR: `docker pull ghcr.io/modm-ext/modm-build-avr:latest`
 * RISC-V: `docker pull ghcr.io/modm-ext/modm-build-risc-v:latest`
 * Hosted (Linux): `docker pull ghcr.io/modm-ext/modm-build-base:latest`
+* ARM Cortex-M with OpenOCD: `docker pull ghcr.io/modm-ext/modm-build-cortex-m-openocd:latest`
+
+
+## Image `modm-ext/modm-build-cortex-m-openocd` with OpenOCD
+
+You can program ARM Cortex-M (STM32, SAMD, ...) targets using the `cortex-m-openocd.Dockerfile` image like this:
+
+```
+docker run -it --rm -v $PWD:$PWD --user $(id -u $USER) -e DIR=$PWD --device=/dev/bus/usb/003/007:/dev/bus/usb/003/007 ghcr.io/modm-ext/modm-build-cortex-m-openocd:latest /bin/bash -c 'cd $DIR && ls && scons program'
+```
+
+Where `$PWD` is your modm project directory and `/dev/bus/usb/003/007:/dev/bus/usb/003/007` is the device, where your programmer is located (for example `ST-LINK/V2.1`).
+
 
 ## Build images
 

--- a/cortex-m-openocd.Dockerfile
+++ b/cortex-m-openocd.Dockerfile
@@ -1,0 +1,8 @@
+FROM ghcr.io/modm-ext/modm-build-cortex-m:TAG
+LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann <raphael+docker@rleh.de>, Christopher Durand <christopher.durand@rwth-aachen.de>, Nick Fiege <nickfiege999@gmail.com>"
+LABEL Description="Image for building, debugging and programming modm for ARM Cortex-M"
+LABEL org.opencontainers.image.source https://github.com/modm-ext/docker-modm-build
+
+RUN wget -qO- https://github.com/xpack-dev-tools/openocd-xpack/releases/download/v0.11.0-3/xpack-openocd-0.11.0-3-linux-x64.tar.gz | tar -xvz -C /opt
+
+ENV PATH "/opt/xpack-openocd-0.11.0-3/bin:$PATH"


### PR DESCRIPTION
@rleh 

 * added an image on top of the existing arm-cortex image which downloads and installs openocd.

We can now create a docker container similiar to this

```
docker run -it --rm    \
   -v $PWD:$PWD --user $(id -u $USER) -e DIR=$PWD  \
   --device=/dev/bus/usb/003/007:/dev/bus/usb/003/007  \
   ghcr.io/modm-ext/modm-build-cortex-m-openocd:testing   \
   /bin/bash -c 'cd $DIR && ls && scons program'
```

whose job it is to mount a device (in this case a specific usb device), mount the current dir and call `scons program` to flash a connected target