### PR TITLE
RISC-V GCC from Embecosm + Update Doxypress + Test docker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,29 +1,30 @@
-name: Build docker images modm-build-*
+name: Build and test docker images modm-build-*
 
 on:
   push:
   workflow_dispatch:
 
 jobs:
-  docker-build:
+  docker-build-base:
     runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.generate_version.outputs.version }}
 
     steps:
       - name: Generate date/version string
+        id: generate_version
         run: |
          export VERSION_TMP="$(date +%F)"
          echo $VERSION_TMP
          echo "VERSION=$VERSION_TMP" >> $GITHUB_ENV
+         echo "version=$VERSION_TMP" >> $GITHUB_OUTPUT
 
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Set FROM image tag/version
         run: |
-         for dockerfile in *.Dockerfile; do
-          sed -i "s/modm-build-base:TAG/modm-build-base:${{ env.VERSION }}/g" $dockerfile
-         done
-         sed -i "s/modm-build-cortex-m:TAG/modm-build-cortex-m:${{ env.VERSION }}/g" cortex-m-openocd.Dockerfile
+         sed -i "s/modm-build-base:TAG/modm-build-base:${{ env.VERSION }}/g" base.Dockerfile
          git diff
 
       - name: Set up Docker Buildx
@@ -37,7 +38,7 @@ jobs:
           password: ${{ secrets.token }}
 
       - name: Build and push modm-build-base
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./base.Dockerfile
@@ -48,8 +49,28 @@ jobs:
             ghcr.io/modm-ext/modm-build-base:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
 
 
+  docker-build-avr:
+    runs-on: ubuntu-22.04
+    needs: docker-build-base
+    env:
+      VERSION: ${{needs.docker-build-base.outputs.version}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set FROM image tag/version
+        run: |
+         sed -i "s/modm-build-base:TAG/modm-build-base:${{ env.VERSION }}/g" avr.Dockerfile
+         git diff
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.user }}
+          password: ${{ secrets.token }}
       - name: Build and push modm-build-avr
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./avr.Dockerfile
@@ -59,8 +80,29 @@ jobs:
             ghcr.io/modm-ext/modm-build-avr:${{ env.VERSION }}
             ghcr.io/modm-ext/modm-build-avr:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
 
+  docker-build-cortex-m:
+    runs-on: ubuntu-22.04
+    needs: docker-build-base
+    env:
+      VERSION: ${{needs.docker-build-base.outputs.version}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set FROM image tag/version
+        run: |
+         sed -i "s/modm-build-base:TAG/modm-build-base:${{ env.VERSION }}/g" cortex-m.Dockerfile
+         sed -i "s/modm-build-cortex-m:TAG/modm-build-cortex-m:${{ env.VERSION }}/g" cortex-m-openocd.Dockerfile
+         git diff
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.user }}
+          password: ${{ secrets.token }}
       - name: Build and push modm-build-cortex-m
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./cortex-m.Dockerfile
@@ -69,9 +111,8 @@ jobs:
           tags: |
             ghcr.io/modm-ext/modm-build-cortex-m:${{ env.VERSION }}
             ghcr.io/modm-ext/modm-build-cortex-m:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
-
       - name: Build and push modm-build-cortex-m-openocd
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./cortex-m-openocd.Dockerfile
@@ -81,8 +122,28 @@ jobs:
             ghcr.io/modm-ext/modm-build-cortex-m-openocd:${{ env.VERSION }}
             ghcr.io/modm-ext/modm-build-cortex-m-openocd:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
 
+  docker-build-risc-v:
+    runs-on: ubuntu-22.04
+    needs: docker-build-base
+    env:
+      VERSION: ${{needs.docker-build-base.outputs.version}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set FROM image tag/version
+        run: |
+         sed -i "s/modm-build-base:TAG/modm-build-base:${{ env.VERSION }}/g" risc-v.Dockerfile
+         git diff
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.user }}
+          password: ${{ secrets.token }}
       - name: Build and push modm-build-risc-v
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./risc-v.Dockerfile
@@ -91,3 +152,104 @@ jobs:
           tags: |
             ghcr.io/modm-ext/modm-build-risc-v:${{ env.VERSION }}
             ghcr.io/modm-ext/modm-build-risc-v:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
+
+  docker-testing-base:
+    runs-on: ubuntu-22.04
+    needs: docker-build-base
+    container:
+      image: ghcr.io/modm-ext/modm-build-base:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          repository: 'modm-io/modm'
+          ref: 'develop'
+          submodules: 'recursive'
+      - name: Fix Git permission/ownership problem
+        run: |
+          git config --global --add safe.directory /__w/docker-modm-build/docker-modm-build
+      - name: Check environment
+        run: |
+          env
+          locale -a
+          python --version  || true
+          python3 --version || true
+          python3 -c "import os; print(os.cpu_count())"
+          which scons
+          scons --version
+          which g++
+          g++ --version
+          which lbuild
+          lbuild --version
+      - name: Hosted Unittests
+        if: always()
+        run: |
+          (cd test && make run-hosted-linux)
+
+  docker-testing-avr:
+    runs-on: ubuntu-22.04
+    needs: docker-build-avr
+    container:
+      image: ghcr.io/modm-ext/modm-build-avr:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          repository: 'modm-io/modm'
+          ref: 'develop'
+          submodules: 'recursive'
+      - name: Fix Git permission/ownership problem
+        run: |
+          git config --global --add safe.directory /__w/docker-modm-build/docker-modm-build
+      - name: Check environment
+        run: |
+          which avr-g++
+          avr-g++ --version
+          avr-g++ --print-multi-lib
+      - name: Examples AVR Series
+        if: always()
+        run: |
+          (cd examples && ../tools/scripts/examples_compile.py arduino_uno arduino_nano)
+
+  docker-testing-cortex-m:
+    runs-on: ubuntu-22.04
+    needs: docker-build-cortex-m
+    container:
+      image: ghcr.io/modm-ext/modm-build-cortex-m:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          repository: 'modm-io/modm'
+          ref: 'develop'
+          submodules: 'recursive'
+      - name: Fix Git permission/ownership problem
+        run: |
+          git config --global --add safe.directory /__w/docker-modm-build/docker-modm-build
+      - name: Check environment
+        run: |
+          which arm-none-eabi-g++
+          arm-none-eabi-g++ --version
+          arm-none-eabi-g++ --print-multi-lib
+      - name: Examples SAMV and STM32G4
+        if: always()
+        run: |
+          (cd examples && ../tools/scripts/examples_compile.py samv)
+          (cd examples && ../tools/scripts/examples_compile.py nucleo_g474re)
+
+  docker-testing-risc-v:
+    runs-on: ubuntu-22.04
+    needs: docker-build-risc-v
+    container:
+      image: ghcr.io/modm-ext/modm-build-risc-v:${{github.ref == 'refs/heads/master' && 'latest' || 'testing' }}
+    steps:
+      - name: Check environment
+        run: |
+          which riscv32-unknown-elf-g++
+          riscv32-unknown-elf-g++ --version
+          riscv32-unknown-elf-g++ --print-multi-lib
+      - name: Compile minimal main.cpp
+        run: |
+          echo "int main() { return 0; }" > /tmp/main.cpp
+          riscv32-unknown-elf-g++ /tmp/main.cpp -o /tmp/main.out
+          file /tmp/main.out

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -48,6 +48,6 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 90 --slave /u
 RUN locale-gen en_US.UTF-8
 RUN pip3 install -r requirements3.txt && rm requirements3.txt
 RUN mkdir /opt/doxypress && \
-    wget -qO- https://github.com/copperspice/doxypress/releases/download/dp-1.5.0/doxypress-1.5.0-ubuntu22.04-x64.tar.bz2 | tar xj -C /opt/doxypress
+    wget -qO- https://github.com/copperspice/doxypress/releases/download/dp-1.5.1/doxypress-1.5.1-ubuntu22.04-x64.tar.bz2 | tar xj -C /opt/doxypress
 
 ENV PATH "/opt/doxypress:$PATH"

--- a/risc-v.Dockerfile
+++ b/risc-v.Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann 
 LABEL Description="Image for building and debugging modm for RISC-V"
 LABEL org.opencontainers.image.source https://github.com/modm-ext/docker-modm-build
 
-RUN wget -qO- https://github.com/modm-io/riscv-gcc/releases/download/v12.2.0/modm-riscv-gcc.tar.bz2 | tar xj -C /opt
+RUN wget -qO- https://buildbot.embecosm.com/job/riscv32-gcc-ubuntu2204-release/4/artifact/riscv32-embecosm-ubuntu2204-gcc12.2.0.tar.gz | tar xz -C /opt
 
-ENV PATH "/opt/modm-riscv-gcc/bin:$PATH"
+ENV PATH "/opt/riscv32-embecosm-ubuntu2204-gcc12.2.0/bin:$PATH"


### PR DESCRIPTION
- [x] Replace RISC-V GCC
    - Embocosm provides compiler packages (GCC multilib, binutils, newlib & GDB) for RISC-V for many host operation systems (including MacOS and Windows(!)): https://www.embecosm.com/resources/tool-chain-downloads/#riscv-stable
    - I don't see the point of maintaining our own gcc distibution, so let's deprecate [modm-io/riscv-gcc](https://github.com/modm-io/riscv-gcc).
- [x] Test created docker images
    - The CI runs some modm test in the freshly built images
- [x] Update Doxypress to version 1.5.1