### PR TITLE
Add libncursesw5 (GDB dependency) to base image

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update -qq && \
       graphviz \
       curl \
       gnupg2 \
+      libncursesw5 \
       clang-format-13 && \
     apt-get clean -qq
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 90 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12 && \


### PR DESCRIPTION
```
> docker run --rm -it ghcr.io/modm-ext/modm-build-cortex-m:latest
root@d8fbff209b23:/work# arm-none-eabi-gdb
arm-none-eabi-gdb: error while loading shared libraries: libncursesw.so.5: cannot open shared object file: No such file or directory
```