### PR TITLE
Update to GCC 14.2

### DIFF
--- a/avr.Dockerfile
+++ b/avr.Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann 
 LABEL Description="Image for building and debugging modm for AVR"
 LABEL org.opencontainers.image.source https://github.com/modm-ext/docker-modm-build
 
-RUN wget -qO- https://github.com/modm-io/avr-gcc/releases/download/v13.2.0/modm-avr-gcc.tar.bz2 | tar xj -C /opt
+RUN wget -qO- https://github.com/modm-io/avr-gcc/releases/download/v14.2.0/modm-avr-gcc.tar.bz2 | tar xj -C /opt
 
 ENV PATH "/opt/avr-gcc/bin:$PATH"

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -47,6 +47,6 @@ RUN apt-get update -qq && \
 RUN locale-gen en_US.UTF-8
 RUN pip3 install --break-system-packages -r requirements3.txt && rm requirements3.txt
 RUN mkdir /opt/doxypress && \
-    wget -qO- https://github.com/copperspice/doxypress/releases/download/dp-1.7.0/doxypress-1.7.0-ubuntu24.04-x64.tar.bz2 | tar xj -C /opt/doxypress
+    wget -qO- https://github.com/copperspice/doxypress/releases/download/dp-2.0.0/doxypress-2.0.0-ubuntu24.04-x64.tar.bz2 | tar xj -C /opt/doxypress
 
 ENV PATH="/opt/doxypress:$PATH"

--- a/cortex-m-openocd.Dockerfile
+++ b/cortex-m-openocd.Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann 
 LABEL Description="Image for building, debugging and programming modm for ARM Cortex-M with OpenOCD"
 LABEL org.opencontainers.image.source https://github.com/modm-ext/docker-modm-build
 
-RUN wget -qO- https://github.com/xpack-dev-tools/openocd-xpack/releases/download/v0.12.0-2/xpack-openocd-0.12.0-2-linux-x64.tar.gz | tar -xvz -C /opt
+RUN wget -qO- https://github.com/xpack-dev-tools/openocd-xpack/releases/download/v0.12.0-6/xpack-openocd-0.12.0-6-linux-x64.tar.gz | tar -xvz -C /opt
 
-ENV PATH "/opt/xpack-openocd-0.12.0-2/bin:$PATH"
+ENV PATH "/opt/xpack-openocd-0.12.0-6/bin:$PATH"

--- a/cortex-m.Dockerfile
+++ b/cortex-m.Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann 
 LABEL Description="Image for building and debugging modm for ARM Cortex-M"
 LABEL org.opencontainers.image.source https://github.com/modm-ext/docker-modm-build
 
-RUN wget -qO- https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v13.2.1-1.1/xpack-arm-none-eabi-gcc-13.2.1-1.1-linux-x64.tar.gz | tar -xz -C /opt
+RUN wget -qO- https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v14.2.1-1.1/xpack-arm-none-eabi-gcc-14.2.1-1.1-linux-x64.tar.gz | tar -xz -C /opt
 
-ENV PATH "/opt/xpack-arm-none-eabi-gcc-13.2.1-1.1/bin:$PATH"
+ENV PATH "/opt/xpack-arm-none-eabi-gcc-14.2.1-1.1/bin:$PATH"

--- a/risc-v.Dockerfile
+++ b/risc-v.Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>, Raphael Lehmann 
 LABEL Description="Image for building and debugging modm for RISC-V"
 LABEL org.opencontainers.image.source https://github.com/modm-ext/docker-modm-build
 
-RUN wget -qO- https://buildbot.embecosm.com/job/riscv32-gcc-ubuntu2204-release/10/artifact/riscv32-embecosm-ubuntu2204-gcc13.2.0.tar.gz | tar -xz -C /opt
+RUN wget -qO- https://buildbot.embecosm.com/job/riscv32-gcc-ubuntu2404-release/1/artifact/riscv32-embecosm-ubuntu2404-gcc14.1.0.tar.gz | tar -xz -C /opt
 
-ENV PATH "/opt/riscv32-embecosm-ubuntu2204-gcc13.2.0/bin:$PATH"
+ENV PATH "/opt/riscv32-embecosm-ubuntu2404-gcc14.1.0/bin:$PATH"


### PR DESCRIPTION
~~Both our own avr-gcc 14 and ZakKemble version sadly crash during [some compilations of modm examples](https://github.com/modm-ext/docker-modm-build/actions/runs/14538930030/job/40793140938).~~

~~The Homebrew avr-gcc 14 version on ARM64 macOS does not crash, however.~~

It was an issue in the CMakefile generator, which generated `-O3`, instead of `-Os` flags, which apparently crashes avr-gcc v14. However, nobody should use `-O3` on AVRs anyways.